### PR TITLE
Feat/#42 페이지 선택기(일정/보관함/참여자)구현 (based on feat/75-sidebarcustom)

### DIFF
--- a/Projects/Rootrip/Rootrip/Views/Sidebar/SegmentedControl/Bookmarks/BookmarkView.swift
+++ b/Projects/Rootrip/Rootrip/Views/Sidebar/SegmentedControl/Bookmarks/BookmarkView.swift
@@ -1,0 +1,19 @@
+//
+//  BookmarkView.swift
+//  Sidebar
+//
+//  Created by MINJEONG on 7/17/25.
+//
+
+import SwiftUI
+
+struct BookmarkView: View {
+    var body: some View {
+        // TODO: 북마크 뷰 구현 예정
+        Text("BookmarkView")
+    }
+}
+
+#Preview(traits: .landscapeLeft) {
+    BookmarkView()
+}

--- a/Projects/Rootrip/Rootrip/Views/Sidebar/SegmentedControl/Particapants/ParticipantsView.swift
+++ b/Projects/Rootrip/Rootrip/Views/Sidebar/SegmentedControl/Particapants/ParticipantsView.swift
@@ -1,0 +1,19 @@
+//
+//  ParticipantsView.swift
+//  Sidebar
+//
+//  Created by MINJEONG on 7/17/25.
+//
+
+import SwiftUI
+
+struct ParticipantsView: View {
+    var body: some View {
+        // TODO: 참여자 뷰 구현 예정
+        Text("ParticipantsView")
+    }
+}
+
+#Preview(traits: .landscapeLeft) {
+    ParticipantsView()
+}

--- a/Projects/Rootrip/Rootrip/Views/Sidebar/SegmentedControl/Plan/PlanView.swift
+++ b/Projects/Rootrip/Rootrip/Views/Sidebar/SegmentedControl/Plan/PlanView.swift
@@ -1,0 +1,18 @@
+//
+//  PlanView.swift
+//  Rootrip
+//
+//  Created by MINJEONG on 7/19/25.
+//
+
+import SwiftUI
+
+struct PlanView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    PlanView()
+}

--- a/Projects/Rootrip/Rootrip/Views/Sidebar/SegmentedControl/SegmentedContolView.swift
+++ b/Projects/Rootrip/Rootrip/Views/Sidebar/SegmentedControl/SegmentedContolView.swift
@@ -1,0 +1,66 @@
+//
+//  SegmentedContolView.swift
+//  Sidebar
+//
+//  Created by MINJEONG on 7/17/25.
+//
+
+import SwiftUI
+/// 상단 탭(일정, 보관함, 참여자)을 선택할 수 있는 세그먼트 뷰입니다.
+/// 선택된 탭에 따라 하위 콘텐츠 뷰가 전환됩니다.
+struct SegmentedContolView: View {
+    @State private var selectedIndex = 0
+    @Namespace private var animation
+    private let segments = ["일정", "보관함", "참여자"]
+
+    var body: some View {
+        // MARK: - Segment Selection
+        HStack(spacing: -4) {
+            ForEach(0..<segments.count, id: \.self) { index in
+                ZStack {
+                    //선택된 세그먼트
+                    if selectedIndex == index {
+                        RoundedRectangle(cornerRadius: 13)
+                            .fill(Color.white)
+                            .matchedGeometryEffect(id: "background", in: animation)
+                            .frame(width: 47, height: 21)
+                    }
+
+                    Text(segments[index])
+                        .font(.system(size: 12))
+                        .foregroundColor(selectedIndex == index ? Color.purple : Color.gray)
+                        .frame(height: 21)
+                        .onTapGesture {
+                            withAnimation(.default) {
+                                selectedIndex = index
+                            }
+                        }
+                }
+                // 각 세그먼트가 HStack 내에서 균등한 너비를 가지도록 설정
+                .frame(maxWidth: .infinity)
+            }
+        }
+        //세그먼트 배경
+        .frame(width: 151, height: 29)
+        .background(Color.gray.opacity(0.2))
+        .clipShape(RoundedRectangle(cornerRadius: 13))
+        .padding(.vertical, 11)
+
+        // MARK: - Child View Rendering (선택된 탭에 따른 하위 뷰 렌더링)
+        Group {
+            switch selectedIndex {
+            case 0: PlanView()
+            case 1: BookmarkView()// TODO: 북마크 뷰 구현 예정
+            case 2: ParticipantsView()// TODO: 참여자 뷰 구현 예정
+            default: EmptyView()
+            }
+        }
+    }
+}
+
+
+#Preview {
+    SegmentedContolView()
+//        .environmentObject(PlanManager())
+//        .environmentObject(UtilPen())
+}

--- a/Projects/Rootrip/Rootrip/Views/Sidebar/SidebarView.swift
+++ b/Projects/Rootrip/Rootrip/Views/Sidebar/SidebarView.swift
@@ -21,8 +21,8 @@ struct SidebarView: View {
             .padding(.top, 64)
             .padding(.trailing, 16)
             
-            //-TODO: #42이슈 브랜치에서 구현한거 연결필요
-            //SegmentedContolView()
+        
+            SegmentedContolView()
             Spacer()
         }
         .frame(width: 259)


### PR DESCRIPTION
Why: 사용자가 페이지(일정/보관함/참여자)를 전환할 수 있어야 함
How: SegmentedContolView를 생성해 SidebarView에 연결추가하고 각 세그먼트 케이스에 해당 View(북마크, 플랜, 참가자) 연결

<!--
🙏 PR 제목 컨벤션 (타입 + 이슈 번호 + 작업 요약(PR제목))
예시: Feature: #167 예약 취소 구현
~~※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!~~
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- 🚨 **이 브랜치는 `feat/75-sidebarcustom` 브랜치를 기반으로 작업되었습니다.**
**따라서 반드시 `feat/75-sidebarcustom` 가 먼저 `main`에 머지된 이후 이 PR을 머지해야 합니다.  
그렇지 않으면 `feat/75-sidebarcustom` 의 변경사항까지 중복으로 포함되어 반영될 수 있습니다.**

- Closes #42 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->
- SegmentedContolView생성 및 SidebarView(#75 TODO해결)에 연결해뒀습니다.
- 각 세그먼트 케이스에 해당하는 BookmarkView(), PlanView(), ParticipantsView() 파일만 생성


---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->
<img width="698" height="474" alt="image" src="https://github.com/user-attachments/assets/6fa3b670-e403-4ddd-b752-fe896f79417a" />

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPad Pro 11-inch, iOS 18.0 환경에서 정상 동작

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 이곳도 마찬가지로 프리뷰에 주석처리되어있는 것은 훗날 제거 될 것 입니다
- #75 브랜치를 베이스로 #42 를 판 이유는 계속 사이드바에 잘 들어갔는지 확인이 필요해 그렇게 작업했습니다


---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- 커스텀된 SegmentedControl 입니다
