### PR TITLE
#25 BlockView(MainView) UI 구현 

### DIFF
--- a/Projects/Rootrip/Rootrip.xcodeproj/project.pbxproj
+++ b/Projects/Rootrip/Rootrip.xcodeproj/project.pbxproj
@@ -10,9 +10,26 @@
 		70C0F47D2E27F624001B81C0 /* Rootrip.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Rootrip.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		60C606632E2BD1C0000D8936 /* Exceptions for "Rootrip" folder in "Rootrip" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Extensions/.gitkeep,
+				Models/.gitkeep,
+				UseCases/.gitkeep,
+				ViewModels/.gitkeep,
+				Views/ViewControllers/.gitkeep,
+			);
+			target = 70C0F47C2E27F624001B81C0 /* Rootrip */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		70C0F47F2E27F624001B81C0 /* Rootrip */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				60C606632E2BD1C0000D8936 /* Exceptions for "Rootrip" folder in "Rootrip" target */,
+			);
 			path = Rootrip;
 			sourceTree = "<group>";
 		};
@@ -249,9 +266,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = JKP8H87ADM;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = JKP8H87ADM;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -259,6 +279,8 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UIStatusBarStyle = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -267,6 +289,8 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.TPAP.Rootrip;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Rootrip_DevProfile;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -281,9 +305,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = JKP8H87ADM;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = JKP8H87ADM;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -291,6 +318,8 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UIStatusBarStyle = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -299,6 +328,8 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.TPAP.Rootrip;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Rootrip_DevProfile;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/Projects/Rootrip/Rootrip/Views/Componants/MainViewToolBar.swift
+++ b/Projects/Rootrip/Rootrip/Views/Componants/MainViewToolBar.swift
@@ -2,6 +2,9 @@ import SwiftUI
 
 // MainViewToolBar: 상단 툴바
 struct MainViewToolBar: View {
+    
+    @State private var isShowingPopover:Bool = false
+    
     var body: some View {
         ZStack {
             HStack {
@@ -11,31 +14,35 @@ struct MainViewToolBar: View {
             }
             
             // 2. 버튼들 (오른쪽 정렬)
-            HStack(spacing: 20) {
+            HStack(spacing: 36) {
                 Spacer() // 왼쪽에 공간을 만들어 버튼들을 오른쪽으로 밉니다.
                 
                 Button(action: {
                     // 일기 추가 액션
                 }) {
                     Image(systemName: "plus")
-                        .font(.title2)
-                        .foregroundColor(.white)
+                        .font(.system(size: 24))
+                        .foregroundStyle(.white)
                 }
                 
                 Button(action: {
                     // 일기 수정 액션
                 }) {
                     Text("선택")
-                        .font(.headline)
-                        .foregroundColor(.white)
+                        .font(.system(size: 20))
+                        .foregroundStyle(.white)
                 }
                 
                 Button(action: {
-                    // 프로필 이동 액션
+                    isShowingPopover.toggle()
                 }) {
-                    Image(systemName: "person.circle.fill")
-                        .font(.title2)
-                        .foregroundColor(.white)
+                    //TODO: 프로필 사진 들어가도록 해야함
+                    Circle()
+                        .frame(width: 34, height: 34)
+                        .foregroundStyle(.white)
+                }
+                .popover(isPresented: $isShowingPopover, arrowEdge: .top) {
+                    ProfilePopover()
                 }
             }
             .padding(.horizontal) // 좌우 여백
@@ -47,5 +54,35 @@ struct MainViewToolBar: View {
             Color.point
                 .ignoresSafeArea(.container, edges: .top)
         )
+    }
+}
+
+// MARK: - 프로필 팝오버 뷰
+struct ProfilePopover: View {
+    var body: some View {
+        VStack {
+            Button {
+                // TODO: 로그아웃 기능 추가
+            } label: {
+                Text("로그아웃")
+                    .foregroundStyle(.red)
+                    .padding(.horizontal, 30)
+                    .padding(.top, 10)
+            }
+            .buttonStyle(.plain)
+            
+            Divider()
+                .padding(.horizontal, 12)
+            
+            Button {
+                // TODO: 탈퇴 기능 추가
+            } label: {
+                Text("탈퇴하기")
+                    .foregroundStyle(.gray)
+                    .padding(.horizontal, 30)
+                    .padding(.bottom, 10)
+            }
+            .buttonStyle(.plain)
+        }
     }
 }

--- a/Projects/Rootrip/Rootrip/Views/Componants/MainViewToolBar.swift
+++ b/Projects/Rootrip/Rootrip/Views/Componants/MainViewToolBar.swift
@@ -4,58 +4,103 @@ import SwiftUI
 struct MainViewToolBar: View {
     
     @State private var isShowingPopover:Bool = false
+    @Binding var isEditing: Bool
+    @Binding var selectedProjects: Set<String>
     
     var body: some View {
-        ZStack {
-            HStack {
-                Text("Rootrip")
-                    .fontWeight(.bold)
-                    .foregroundColor(.white)
+        GeometryReader { geometry in
+            let screenWidth = UIScreen.main.bounds.width
+            let trailingPadding: CGFloat = screenWidth >= 1300 ? 20 : 60
+            ZStack {
+                HStack {
+                    Text("Rootrip")
+                        .fontWeight(.bold)
+                        .foregroundColor(.white)
+                }
+                
+                // 2. 버튼들 (오른쪽 정렬)
+                HStack(spacing: 36) {
+                    Spacer()
+                    
+                    if isEditing {
+                        editingButtons
+                    } else {
+                        normalButtons
+                    }
+                }
+                .padding(.trailing, trailingPadding)
+            }
+            .frame(height: 50) // 툴바 콘텐츠의 높이 지정
+            .background(
+                // 3. 배경색을 ZStack의 background 수정자로 이동시킵니다.
+                //    이렇게 하면 배경에만 ignoresSafeArea가 적용됩니다.
+                Color.point
+                    .ignoresSafeArea(.container, edges: .top)
+            )
+        }
+    }
+    // MARK: - 선택 모드 버튼
+    private var editingButtons: some View {
+        Group {
+            Button {
+                isEditing = false
+            } label: {
+                Text("삭제")
+                    .font(.system(size: 20))
+                    .foregroundStyle(.red)
+                    .bold()
+            }
+            .disabled(selectedProjects.isEmpty)
+            .opacity(selectedProjects.isEmpty ? 0.5 : 1.0)
+            
+            Button {
+                isEditing = false
+                selectedProjects.removeAll()
+            } label: {
+                Text("완료")
+                    .font(.system(size: 20))
+                    .foregroundStyle(.white)
+                    .bold()
+            }
+        }
+    }
+    
+    // MARK: - 기본 모드 버튼
+    private var normalButtons: some View {
+        Group {
+            NavigationLink {
+                // TODO: Plan 생성 화면으로 이동
+                EmptyView()
+            } label: {
+                Image(systemName: "plus")
+                    .font(.system(size: 20))
+                    .foregroundStyle(.white)
             }
             
-            // 2. 버튼들 (오른쪽 정렬)
-            HStack(spacing: 36) {
-                Spacer() // 왼쪽에 공간을 만들어 버튼들을 오른쪽으로 밉니다.
-                
-                Button(action: {
-                    // 일기 추가 액션
-                }) {
-                    Image(systemName: "plus")
-                        .font(.system(size: 24))
-                        .foregroundStyle(.white)
-                }
-                
-                Button(action: {
-                    // 일기 수정 액션
-                }) {
-                    Text("선택")
-                        .font(.system(size: 20))
-                        .foregroundStyle(.white)
-                }
-                
-                Button(action: {
-                    isShowingPopover.toggle()
-                }) {
-                    //TODO: 프로필 사진 들어가도록 해야함
-                    Circle()
-                        .frame(width: 34, height: 34)
-                        .foregroundStyle(.white)
-                }
-                .popover(isPresented: $isShowingPopover, arrowEdge: .top) {
-                    ProfilePopover()
-                }
+            Button {
+                isEditing = true
+                selectedProjects.removeAll() //선택을 전부 해제
+            } label: {
+                Text("선택")
+                    .font(.system(size: 20))
+                    .foregroundStyle(.white)
             }
-            .padding(.horizontal) // 좌우 여백
+            
+            Button {
+                isShowingPopover.toggle()
+            } label: {
+                Circle()
+                    .frame(width: 34, height: 34)
+                    .foregroundStyle(.white)
+            }
+            .popover(isPresented: $isShowingPopover, arrowEdge: .top) {
+                ProfilePopover()
+            }
         }
-        .frame(height: 50) // 툴바 콘텐츠의 높이 지정
-        .background(
-            // 3. 배경색을 ZStack의 background 수정자로 이동시킵니다.
-            //    이렇게 하면 배경에만 ignoresSafeArea가 적용됩니다.
-            Color.point
-                .ignoresSafeArea(.container, edges: .top)
-        )
     }
 }
+
+
 
 // MARK: - 프로필 팝오버 뷰
 struct ProfilePopover: View {

--- a/Projects/Rootrip/Rootrip/Views/Componants/ProjectCard.swift
+++ b/Projects/Rootrip/Rootrip/Views/Componants/ProjectCard.swift
@@ -1,0 +1,114 @@
+//
+//  ProjectCard.swift
+//  Rootrip
+//
+//  Created by Ella's Mac on 7/20/25.
+//
+
+import SwiftUI
+
+struct ProjectCard: View {
+    let project: Project
+    var isHighlighted: Bool = false // 최신순으로 정렬
+    var isEditing: Bool = true
+    var isSelected: Bool = true
+    
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            // TODO: 지도 이미지 들어가도록 만들어야함
+            Rectangle()
+                .foregroundStyle(.white)
+                .frame(maxWidth: isHighlighted ? 1070 : 325, maxHeight: isHighlighted ? 380 : 190)
+                .clipped()
+                .overlay(
+                    ZStack {
+                        LinearGradient(
+                            gradient: Gradient(colors: [Color.point.opacity(0.7), .clear]),
+                            startPoint: .bottom,
+                            endPoint: .center
+                        )
+                        
+                        //카드에 들어가는 텍스트 (제목, 날짜 등)
+                        VStack {
+                            Spacer()
+                            HStack {
+                                // 여행 제목
+                                Text(project.title)
+                                    .font(.system(size: isHighlighted ? 32 : 18, weight: .bold))
+                                    .foregroundColor(.white)
+                                    .multilineTextAlignment(.leading)
+                                
+                                Spacer()
+                                
+                                // 날짜 표시
+                                VStack(alignment: .trailing, spacing: 4) {
+                                    if let end = project.endDate {
+                                        VStack (spacing: 4) {
+                                            Text(formattedDate(project.startDate))
+                                            
+                                            Rectangle()
+                                                .fill(Color.white)
+                                                .frame(width:isHighlighted ? 20: 14,
+                                                       height: 1)
+                                            
+                                            Text(formattedDate(end))
+                                        }
+                                    } else {
+                                        Text(formattedDate(project.startDate))
+                                    }
+                                }
+                                .font(.system(size: isHighlighted ? 20 : 12, weight: .bold))
+                                .foregroundColor(.white.opacity(0.9))
+                            }
+                            .padding(isHighlighted ? 24 : 16)
+                        }
+                    }
+                )
+                .cornerRadius(16)
+                .shadow(color: .gray.opacity(0.4),
+                        radius: isHighlighted ? 8 : 4, x: 0, y: 2)
+            
+            
+            // 편집 모드일 때 체크 동그라미
+            //TODO: asset정해지면 체크박스 색상 수정해야함
+            if isEditing {
+                let size: CGFloat = isHighlighted ? 39 : 33
+                let checkmarkSize: CGFloat = isHighlighted ? 16 : 12
+                let padding: CGFloat = isHighlighted ? 16 : 10
+                
+                ZStack {
+                    Circle()
+                        .strokeBorder(Color.white, lineWidth: 3)
+                        .background(Circle().fill(isSelected ? Color.green : Color.gray))
+                        .frame(width: size, height: size)
+                    
+                    if isSelected {
+                        Image(systemName: "checkmark")
+                            .font(.system(size: checkmarkSize, weight: .bold))
+                            .foregroundColor(.white)
+                    }
+                }
+                .padding(padding)
+            }
+        }
+    }
+    
+    private func formattedDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy.MM.dd"
+        return formatter.string(from: date)
+    }
+}
+
+//MARK: - Preview
+#Preview(traits: .landscapeLeft) {
+    ProjectCard(
+        project: Project(
+            title: "TPAP 우정 여행",
+            tripType: .overnightTrip,
+            startDate: Date(),
+            endDate: Calendar.current.date(byAdding: .day, value: 1, to: Date())
+        ),
+        isHighlighted: true
+    )
+}

--- a/Projects/Rootrip/Rootrip/Views/Componants/ProjectCard.swift
+++ b/Projects/Rootrip/Rootrip/Views/Componants/ProjectCard.swift
@@ -1,10 +1,3 @@
-//
-//  ProjectCard.swift
-//  Rootrip
-//
-//  Created by Ella's Mac on 7/20/25.
-//
-
 import SwiftUI
 
 struct ProjectCard: View {

--- a/Projects/Rootrip/Rootrip/Views/MainView.swift
+++ b/Projects/Rootrip/Rootrip/Views/MainView.swift
@@ -1,46 +1,70 @@
 import SwiftUI
 
 struct MainView: View {
-    @State var showMapCanvas = false
-    
+    @State private var isEditing: Bool = false
+    @State private var selectedProjects: Set<String> = []
+
     var body: some View {
-        if !showMapCanvas {
-            VStack {
-                MainViewToolBar()
-                
-                Rectangle()
-                    .fill(
-                        LinearGradient(
-                            gradient: Gradient(colors: [Color.point, Color.point.opacity(0.2)]),
-                            startPoint: .bottom,
-                            endPoint: .top
+        NavigationStack {
+            ZStack(alignment: .top) {
+                //TODO: backgroundColor 추가해야함
+                Color.white
+                    .ignoresSafeArea()
+
+                VStack(spacing: 0) {
+                    ScrollView {
+                        Spacer()
+                            .frame(height: 100)
+
+                        ProjectListView(
+                            projects: sampleProjects,
+                            selectedProjects: $selectedProjects,
+                            isEditing: $isEditing
                         )
-                    )
-                    .frame(height: UIScreen.main.bounds.height / 2.5)
-                    .cornerRadius(20)
-                    .padding(50)
-                    .shadow(radius: 10)
-                    .overlay(
-                        Text("눌러서 MapCanvas로 이동")
-                            .font(.title)
-                            .fontWeight(.bold)
-                            .foregroundColor(.white)
-                    )
-                    .onTapGesture {
-                        withAnimation(.linear) {
-                            showMapCanvas = true
-                        }
                     }
-                Spacer()
+                }
+
+
+                MainViewToolBar(
+                    isEditing: $isEditing,
+                    selectedProjects: $selectedProjects
+                )
             }
-            
-        } else {
-            MapCanvas(showMapCanvas: $showMapCanvas)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar(.hidden)
         }
     }
 }
 
+// 샘플 데이터용 ID를 String으로 변환
+var sampleProjects: [Project] = {
+    var p1 = Project(
+        title: "TPAP 우정 여행",
+        tripType: .overnightTrip,
+        startDate: Date(),
+        endDate: Calendar.current.date(byAdding: .day, value: 1, to: Date())
+    )
+    p1.id = "sample-1"
 
-#Preview {
+    var p2 = Project(
+        title: "퍼스널 크루 여행",
+        tripType: .dayTrip,
+        startDate: Date(),
+        endDate: Calendar.current.date(byAdding: .day, value: 3, to: Date())
+    )
+    p2.id = "sample-2"
+
+    var p3 = Project(
+        title: "퍼스널 크루 여행",
+        tripType: .dayTrip,
+        startDate: Date(),
+        endDate: Calendar.current.date(byAdding: .day, value: 3, to: Date())
+    )
+    p3.id = "sample-3"
+
+    return [p1, p2, p3]
+}()
+
+#Preview(traits: .landscapeLeft) {
     MainView()
 }

--- a/Projects/Rootrip/Rootrip/Views/ProjectListView.swift
+++ b/Projects/Rootrip/Rootrip/Views/ProjectListView.swift
@@ -1,0 +1,146 @@
+// ProjectListView, LargeCardView, SmallCardRowView 세 컴포넌트로 구성
+// selectedProjects는 Set<String>으로, 정렬은 createdDate 기준
+//TODO: 카드뷰 눌렀을때 DetailView로 넘어가도록 해야함
+import SwiftUI
+
+// MARK: - ProjectListView
+struct ProjectListView: View {
+    let projects: [Project]
+    @Binding var selectedProjects: Set<String> // Firebase용 id는 String
+    @Binding var isEditing: Bool
+    
+    var sortedProjects: [Project] {
+        projects.sorted { $0.createdDate > $1.createdDate }
+    }
+    
+    var body: some View {
+        VStack(spacing: 32) {
+            
+            // 가장 최신 프로젝트
+            if let first = sortedProjects.first {
+                HStack {
+                    Spacer()
+                    LargeCardView(
+                        project: first,
+                        isEditing: isEditing,
+                        isSelected: selectedProjects.contains(first.id ?? ""),
+                        toggleSelection: {
+                            toggleSelection(for: first.id)
+                        }
+                    )
+                    .frame(width: 1070, height: 380)
+                    Spacer()
+                }
+                .padding(.horizontal, 100)
+            }
+            
+            // 나머지 프로젝트 (작은 카드 3개씩)
+            let smallProjects = Array(sortedProjects.dropFirst())
+            
+            ForEach(Array(stride(from: 0, to: smallProjects.count, by: 3)), id: \.self) { index in
+                SmallCardRowView(
+                    projects: smallProjects,
+                    startIndex: index,
+                    isEditing: isEditing,
+                    selectedProjects: $selectedProjects
+                )
+            }
+        }
+    }
+    
+    private func toggleSelection(for id: String?) {
+        guard let id else { return }
+        if selectedProjects.contains(id) {
+            selectedProjects.remove(id)
+        } else {
+            selectedProjects.insert(id)
+        }
+    }
+}
+
+// MARK: - LargeCardView
+struct LargeCardView: View {
+    let project: Project
+    var isEditing: Bool
+    var isSelected: Bool
+    var toggleSelection: () -> Void
+
+    var body: some View {
+        if isEditing {
+            Button(action: toggleSelection) {
+                ProjectCard(
+                    project: project,
+                    isHighlighted: true,
+                    isEditing: true,
+                    isSelected: isSelected
+                )
+            }
+            .buttonStyle(.plain)
+        } else {
+            NavigationLink(destination: EmptyView()) {
+                ProjectCard(
+                    project: project,
+                    isHighlighted: true,
+                    isEditing: false,
+                    isSelected: false
+                )
+            }
+            .buttonStyle(.plain)
+        }
+    }
+}
+
+// MARK: - SmallCardRowView
+struct SmallCardRowView: View {
+    let projects: [Project]
+    let startIndex: Int
+    let isEditing: Bool
+    @Binding var selectedProjects: Set<String>
+    
+    var body: some View {
+        HStack(spacing: 44) {
+            ForEach(0..<3) { offset in
+                if startIndex + offset < projects.count {
+                    let project = projects[startIndex + offset]
+                    if isEditing {
+                        Button {
+                            toggleSelection(for: project.id)
+                        } label: {
+                            ProjectCard(
+                                project: project,
+                                isHighlighted: false,
+                                isEditing: true,
+                                isSelected: selectedProjects.contains(project.id ?? "")
+                            )
+                            .frame(width: 325, height: 190)
+                        }
+                        .buttonStyle(.plain)
+                    } else {
+                        NavigationLink(destination: EmptyView()) {
+                            ProjectCard(
+                                project: project,
+                                isHighlighted: false,
+                                isEditing: false,
+                                isSelected: false
+                            )
+                            .frame(width: 325, height: 190)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                } else {
+                    Spacer().frame(width: 325)
+                }
+            }
+        }
+    }
+    
+    //Firebase에서 불러온 데이터를 UI에서 사용하기 위한 함수
+    private func toggleSelection(for id: String?) {
+        guard let id else { return }
+        if selectedProjects.contains(id) {
+            selectedProjects.remove(id)
+        } else {
+            selectedProjects.insert(id)
+        }
+    }
+}


### PR DESCRIPTION
## ✨ What’s this PR?

### 📌 관련 이슈 (Related Issue)
- Closes #25

---

### 🧶 주요 변경 내용 (Summary)

- `MainViewToolBar`에 편집 모드 상태 (`isEditing`, `selectedProjects`) 연동
- 프로젝트 컴포넌트 및 리스트 생성
- 선택/완료/삭제 버튼 구현 및 편집 모드 로직 분기 처리
- 선택된 프로젝트가 없을 경우 삭제 버튼 비활성화
- 샘플 프로젝트에 `id` 수동 지정 → 체크박스 UI 정상 동작 확인 가능

---

### 📸 스크린샷 (Optional)


<img width="603" height="412" alt="스크린샷 2025-07-20 오후 8 36 07" src="https://github.com/user-attachments/assets/68ae3454-559c-4b0d-91e9-7934e0b938b4" />

---

### 🧪 테스트 / 검증 내역

- [x] 툴바 버튼 클릭 시 편집 모드 진입/해제 정상 동작 확인
- [x] 체크박스 선택/해제 시 `selectedProjects` 상태 업데이트 확인
- [x] 선택된 프로젝트가 없을 때 삭제 버튼 비활성화 확인
- [x] 샘플 데이터에서도 체크박스 동작 테스트 완료

---

### 💬 기타 공유 사항

- 삭제 동작 자체는 아직 구현되지 않았으며, 후속 PR에서 처리 예정
- 샘플 데이터는 `id` 값을 명시적으로 지정해 사용 중
- 추후 실제 DB 연동 시 `@DocumentID`에 자동 할당될 예정
- 추후 배경색상 및 체크박스 색상 수정할 예정
- 맵 뷰가 각 블록에서 뜨도록 수정할 예정
