### PR TITLE
#6 펜 굵기 슬라이더 UI 구현

### DIFF
--- a/Projects/Rootrip/Rootrip.xcodeproj/project.pbxproj
+++ b/Projects/Rootrip/Rootrip.xcodeproj/project.pbxproj
@@ -10,9 +10,26 @@
 		70C0F47D2E27F624001B81C0 /* Rootrip.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Rootrip.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		60C606632E2BD1C0000D8936 /* Exceptions for "Rootrip" folder in "Rootrip" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Extensions/.gitkeep,
+				Models/.gitkeep,
+				UseCases/.gitkeep,
+				ViewModels/.gitkeep,
+				Views/ViewControllers/.gitkeep,
+			);
+			target = 70C0F47C2E27F624001B81C0 /* Rootrip */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		70C0F47F2E27F624001B81C0 /* Rootrip */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				60C606632E2BD1C0000D8936 /* Exceptions for "Rootrip" folder in "Rootrip" target */,
+			);
 			path = Rootrip;
 			sourceTree = "<group>";
 		};
@@ -249,9 +266,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = JKP8H87ADM;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = JKP8H87ADM;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -259,6 +279,8 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UIStatusBarStyle = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -267,6 +289,8 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.TPAP.Rootrip;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Rootrip_DevProfile;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -281,9 +305,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = JKP8H87ADM;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = JKP8H87ADM;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -291,6 +318,8 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UIStatusBarStyle = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -299,6 +328,8 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.TPAP.Rootrip;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Rootrip_DevProfile;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/Projects/Rootrip/Rootrip/Views/Componants/PenThicknessSlider.swift
+++ b/Projects/Rootrip/Rootrip/Views/Componants/PenThicknessSlider.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+
+struct PenThicknessSlider: View {
+    @State var thickness: CGFloat = 1.0 //TODO: 굵기 관리하는 뷰에서 바인딩 필요
+
+    let minThickness: CGFloat = 1
+    let maxThickness: CGFloat = 20
+
+    let trackWidth: CGFloat = 131
+    let trackHeight: CGFloat = 16
+    let handleSize: CGFloat = 26
+
+    var body: some View {
+        ZStack(alignment: .leading) {
+            PencilBarShape()
+                .fill(Color.gray) //TODO: 색상수정필요
+                .frame(width: trackWidth, height: trackHeight)
+
+            Circle()
+                .stroke(Color.black, lineWidth: 2)
+                .background(Circle().fill(Color.white))
+                .frame(width: handleSize, height: handleSize)
+                .offset(x: handleOffset(for: thickness))
+                .gesture(
+                    DragGesture()
+                        .onChanged { value in
+                            let location = value.location.x
+                            let clamped = min(max(0, location), trackWidth)
+                            let percent = clamped / trackWidth
+                            thickness = minThickness + percent * (maxThickness - minThickness)
+                        }
+                )
+        }
+        .frame(width: trackWidth, height: handleSize)
+    }
+
+    private func handleOffset(for thickness: CGFloat) -> CGFloat {
+        let percent = (thickness - minThickness) / (maxThickness - minThickness)
+        return percent * trackWidth - handleSize / 2
+    }
+}
+    
+    
+struct PencilBarShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+
+        let thinHeight: CGFloat = 2
+        let fatHeight = rect.height
+        let radius = fatHeight / 2
+        let centerY = rect.midY
+
+        path.move(to: CGPoint(x: 0, y: centerY - thinHeight / 2))
+        path.addLine(to: CGPoint(x: rect.maxX - radius, y: centerY - fatHeight / 2))
+        path.addArc(center: CGPoint(x: rect.maxX - radius, y: centerY),
+                    radius: radius,
+                    startAngle: .degrees(-90),
+                    endAngle: .degrees(90),
+                    clockwise: false)
+        path.addLine(to: CGPoint(x: 0, y: centerY + thinHeight / 2))
+        path.closeSubpath()
+
+        return path
+    }
+}
+
+#Preview {
+    PenThicknessSlider()
+}


### PR DESCRIPTION
## ✨ What’s this PR?

### 📌 관련 이슈 (Related Issue)
- Closes #6 

---

### 🧶 주요 변경 내용 (Summary)

- 커스텀 펜 굵기 슬라이더 컴포넌트 `PenThicknessSlider` 구현
- 커스텀 모양의 `PencilBarShape` 포함
- 현재는 로컬 상태(`@State`)로 동작하며, 향후 펜 설정 뷰와 바인딩 예정
- PencilKit 연동은 추후 PR에서 처리 예정

---

### 📸 스크린샷 (Optional)

<img width="135" height="89" alt="스크린샷 2025-07-20 오후 8 55 15" src="https://github.com/user-attachments/assets/e910d46b-db59-4240-8082-66effd368046" />

---

### 🧪 테스트 / 검증 내역

- [x] 슬라이더 드래그 시 굵기 값 실시간 변경 확인(따로 만들어서 확인했습니당)
- [x] min/max 범위 내에서 정상 작동 확인
- [x] 디자인에 맞춘 트랙/핸들 UI 확인

---

### 💬 기타 공유 사항

- PencilKit과 실제 펜 굵기 연동은 아직 미구현 상태이며, 실제 canvas생성 이후 구현예정
- 슬라이더는 독립적인 UI 컴포넌트로 재사용 가능하도록 설계