### PR TITLE
#120 섹션버튼 로직 추가

### DIFF
--- a/Projects/Rootrip/Rootrip/ViewModels/PlanManager.swift
+++ b/Projects/Rootrip/Rootrip/ViewModels/PlanManager.swift
@@ -170,6 +170,20 @@ class PlanManager: ObservableObject {
             addAnnotation(for: selectedDetails[1], to: mapView)
             routeManager.zoomToRegion(containing: [start, end])
         }
+        //선택이 전부 해제된 경우 → 전체 Plan 경로 다시 표시
+        if selectedDetails.isEmpty {
+            for detail in details {
+                addAnnotation(for: detail, to: mapView)
+            }
+
+            let coordinates = details.map { $0.coordinate }
+            if coordinates.count >= 2 {
+                for i in 0..<coordinates.count - 1 {
+                    routeManager.showRoute(from: coordinates[i], to: coordinates[i + 1], on: mapView) { _ in }
+                }
+            }
+            routeManager.zoomToRegion(containing: coordinates)
+        }
     }
     
     


### PR DESCRIPTION
why: 섹션버튼 내부 장소 누른 후 해제했을때 전체 경로가 안보였음
how: 선택이 전부 해제된 경우 → 전체 Plan 경로 다시 표시하는 로직 추가

<!--
🙏 PR 제목 컨벤션 (타입 + 이슈 번호 + 작업 요약(PR제목))
예시: Feature: #167 예약 취소 구현
~~※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!~~
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #120 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->
- 플렌 섹션버튼 선택 중인 상태에서 장소 선택했다가 전부 해제된 경우 → 전체 Plan 경로 다시 표시하는 로직 추가
---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

변동없음

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPad Pro 11-inch, iOS 18.0 환경에서 정상 동작

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 해당 사항을 발견해준 엘라 thx
---
