### PR TITLE
#160 LocationManager 중복생성 문제해결 

### DIFF
--- a/Projects/Rootrip/Rootrip/ViewModels/LocationManager.swift
+++ b/Projects/Rootrip/Rootrip/ViewModels/LocationManager.swift
@@ -6,11 +6,25 @@ import Foundation
 class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
     private let manager = CLLocationManager()
     @Published var location: CLLocation?
-    @Published var mapView = MKMapView()
+    
+    weak var mapView: MKMapView?
 
+    override init() {
+        super.init()
+        manager.delegate = self
+        manager.desiredAccuracy = kCLLocationAccuracyBest
+        manager.requestWhenInUseAuthorization()
+        manager.startUpdatingLocation()
+    }
+    
+    func setMapView(_ mapView: MKMapView) {
+        self.mapView = mapView
+    }
+    
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         location = locations.first
     }
+    
     // MARK: - 지도 경로 랜더링 및 도보 소요시간 반환
     /// MapKit 경로를 지도에 표시하고 예상 도보 시간을 반환
     func showRoute(
@@ -19,6 +33,11 @@ class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
         on mapView: MKMapView,
         completion: @escaping (TimeInterval?) -> Void
     ) {
+        guard let targetMapView = self.mapView else {
+            completion(nil)
+            return
+        }
+        
         let stt = MKPlacemark(coordinate: start)
         let end = MKPlacemark(coordinate: end)
         let sttItem = MKMapItem(placemark: stt)
@@ -28,39 +47,37 @@ class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
         request.source = sttItem
         request.destination = endItem
         request.transportType = .walking
-        //request.transportType = .automobile
         
         let directions = MKDirections(request: request)
         directions.calculate { response, error in
             guard let route = response?.routes.first else {
-                print(
-                    "utilPen error: \(error?.localizedDescription ?? "unknown error on showRoute function")"
-                )
+                print("Route error: \(error?.localizedDescription ?? "unknown error on showRoute function")")
                 completion(nil)
                 return
             }
-            mapView.addOverlay(route.polyline)
             
-            /// 중간 지점 계산
-            let polylinePoints = route.polyline.points()
-            let midPoint = polylinePoints[route.polyline.pointCount / 2].coordinate
-            
-            /// 소요시간 어노테이션 추가
-            // TODO: - 도보 타이틀 제거 시킴으로써 RouteMapRepresentable에 불필요한 코드 삭제
-            let annotation = MKPointAnnotation()
-            annotation.coordinate = midPoint
-            annotation.title = "도보 \(Int(route.expectedTravelTime / 60))분"
-            //            annotation.title = "차량 \(Int(route.expectedTravelTime / 60))분"
-            mapView.addAnnotation(annotation)
+            DispatchQueue.main.async {
+                targetMapView.addOverlay(route.polyline)
+                
+                // 중간 지점 계산
+                let polylinePoints = route.polyline.points()
+                let midPoint = polylinePoints[route.polyline.pointCount / 2].coordinate
+                
+                // 소요시간 어노테이션 추가
+                let annotation = MKPointAnnotation()
+                annotation.coordinate = midPoint
+                annotation.title = "도보 \(Int(route.expectedTravelTime / 60))분"
+                targetMapView.addAnnotation(annotation)
+            }
             
             completion(route.expectedTravelTime)
         }
     }
 
-
     // MARK: - Zoom 및 Shape 유틸리티
     func zoomToRegion(containing coordinates: [CLLocationCoordinate2D], animated: Bool = true) {
         guard !coordinates.isEmpty else { return }
+        guard let mapView = self.mapView else { return }
         
         var rect = MKMapRect.null
         for coordinate in coordinates {
@@ -68,7 +85,8 @@ class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
             rect = rect.union(MKMapRect(origin: point, size: MKMapSize(width: 0, height: 0)))
         }
         
-        mapView.setVisibleMapRect(rect, edgePadding: UIEdgeInsets(top: 80, left: 40, bottom: 80, right: 40), animated: animated)
+        DispatchQueue.main.async {
+            mapView.setVisibleMapRect(rect, edgePadding: UIEdgeInsets(top: 80, left: 40, bottom: 80, right: 40), animated: animated)
+        }
     }
 }
-

--- a/Projects/Rootrip/Rootrip/Views/Canvas/MapCanvasView.swift
+++ b/Projects/Rootrip/Rootrip/Views/Canvas/MapCanvasView.swift
@@ -10,6 +10,9 @@ import SwiftUI
 
 struct MapCanvasView: View {
     @ObservedObject var viewModel: MapViewModel
+    @EnvironmentObject var locationManager: LocationManager
+    @EnvironmentObject var planManager: PlanManager
+    @EnvironmentObject var bookmarkManager: BookmarkManager
     
     @Binding var shouldCenterOnUser: Bool
     @Binding var isUtilPen: Bool
@@ -74,6 +77,9 @@ struct MapCanvasView: View {
         )
         .onAppear {
             mapView.delegate = MapDelegate.shared
+            locationManager.setMapView(mapView)
+            planManager.configure(with: locationManager)
+            bookmarkManager.configure(with: locationManager)
         }
     }
 }

--- a/Projects/Rootrip/Rootrip/Views/Map/MapView.swift
+++ b/Projects/Rootrip/Rootrip/Views/Map/MapView.swift
@@ -19,7 +19,7 @@ import Combine
 struct MapView: UIViewRepresentable {
     // MARK: - 속성
     /// 위치 정보를 관리하는 매니저 (CoreLocation 사용)
-    @ObservedObject private var locationManager = LocationManager()
+    @EnvironmentObject var locationManager: LocationManager
     
     /// POI 어노테이션 및 지역 계산 로직을 가진 ViewModel
     var viewModel: MapViewModel

--- a/Projects/Rootrip/Rootrip/Views/ProjectView.swift
+++ b/Projects/Rootrip/Rootrip/Views/ProjectView.swift
@@ -11,10 +11,11 @@ import SwiftUI
 
 struct ProjectView: View {
     let project: Project
-    @StateObject private var mapState = LocationManager()
+    @EnvironmentObject  var mapState: LocationManager
+    @EnvironmentObject var planManager: PlanManager
+
     @StateObject private var viewModel = MapViewModel()
     
-    @EnvironmentObject var planManager: PlanManager
 
     @State private var hasLoadedPlans = false
     @State private var shouldCenterOnUser = false

--- a/Projects/Rootrip/Rootrip/Views/Sidebar/SegmentedControl/Bookmark/BookmarkButton.swift
+++ b/Projects/Rootrip/Rootrip/Views/Sidebar/SegmentedControl/Bookmark/BookmarkButton.swift
@@ -46,10 +46,6 @@ struct BookmarkButton: View {
                     )
             }
         }
-        // 뷰가 나타날 때 routeManager 설정
-        .onAppear {
-            bookmarkManager.configure(with: locationManager)
-        }
         .onChange(of: isEditing) { _, newValue in
             if newValue {
                 bookmarkManager.resetSelections()

--- a/Projects/Rootrip/Rootrip/Views/Sidebar/SegmentedControl/Plan/PlanButton.swift
+++ b/Projects/Rootrip/Rootrip/Views/Sidebar/SegmentedControl/Plan/PlanButton.swift
@@ -48,9 +48,6 @@ struct PlanButton: View {
                     )
             }
         }
-        .onAppear {
-            planManager.configure(with: locationManager)
-        }
         .onChange(of: isEditing) { _, newValue in
             if newValue {
                 planManager.resetSelections()


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)

- Closes #160 

---

### 🧶 주요 변경 내용 (Summary)

1. LocationManager 구조 변경
- `mapView`를 직접 소유하지 않고, 외부에서 주입받는 방식으로 수정했습니다.


2. 단일 인스턴스 공유
- `App.swift`에서 LocationManager를 생성 후 `@EnvironmentObject`로 공유되도록 했습니다.
- MapCanvasView에서 `mapView`를 생성하고, `onAppear`에서 `locationManager.setMapView()` 호출해서 연결했습니다.
- `PlanManager`, `BookmarkManager`도 동일한 인스턴스를 사용하도록 `configure(with:)` 방식 적용해보았습니다.

3. 중복 configure 제거
- `PlanButton`, `BookmarkButton` 등에서 중복 호출되던 `configure` 제거하고 MapCanvasView 한 곳에서만 설정되도록 통일했습니다.

---

### 🧪 테스트 / 검증 내역
- [x] UI 정상 동작 확인
- [x ] iPad Pro 11-inch, iOS 18.0 환경에서 정상 동작

---

### 💬 기타 공유 사항
- 커스텀한 팝오버가 뜨지 않아요! 경로 색상도 수정이 필요합니다.
- 딘이 올린 위치 권한 코드가 제 코드에도 존재합니다. 아까 테스트 겸 적었다가.. push다 하고 깨달아버렸어요..
---
